### PR TITLE
2017 optimizations

### DIFF
--- a/papers/oleksandr_pavlyk/numba/svml.rst
+++ b/papers/oleksandr_pavlyk/numba/svml.rst
@@ -12,20 +12,20 @@ where a computer program is converted from a scalar implementation, which proces
 to a vector implementation, which processes one operation on multiple pairs of operands at once.
 
 According Numba's project page Numba is an Open Source NumPy-aware optimizing compiler for Python. 
-It uses the remarkable LLVM compiler infrastructure to compile Python syntax to machine code. And it quite expected that NUMBA tries 
+It uses the remarkable LLVM compiler infrastructure to compile Python syntax to machine code. And it quite expected that Numba tries
 to use all this features to improve performance especially for scientific applications. 
 
 
 LLVM implemented autovectorization for simple cases several years ago but there was quite sigificant problem with math functions.
 For proper vectorization it's needed to have special vectorized implementation of math fucntions as sin, cos, exp... 
 
-The Intel® C++ Compiler provides short vector math library (SVML) intrinsics to compute vector math functions. 
+The Intel |R| C++ Compiler provides short vector math library (SVML) intrinsics to compute vector math functions.
 These intrinsics are available for IA-32 and Intel® 64 architectures running on supported operating systems.
 
-The SVML intrinsics are vector variants of corresponding scalar math operations using __m128, __m128d, __m256, __m256d, and __m256i data types.
+The SVML intrinsics are vector variants of corresponding scalar math operations using ``__m128``, ``__m128d``, ``__m256``, ``__m256d``, and ``__m256i`` data types.
 They take packed vector arguments, perform the operation on each element of the packed vector argument, and return a packed vector result.
 
-For example, the argument to the _mm_sin_ps intrinsic is a packed 128-bit vector of four 32-bit precision floating point numbers. The intrinsic computes the sine of each of these four numbers and returns the four results in a packed 128-bit vector.
+For example, the argument to the ``_mm_sin_ps`` intrinsic is a packed 128-bit vector of four 32-bit precision floating point numbers. The intrinsic computes the sine of each of these four numbers and returns the four results in a packed 128-bit vector.
 
 Using SVML intrinsics is faster than repeatedly calling the scalar math functions. However, the intrinsics differ from the scalar functions in accuracy.
 

--- a/papers/oleksandr_pavlyk/optimizations.rst
+++ b/papers/oleksandr_pavlyk/optimizations.rst
@@ -47,7 +47,7 @@ Accelerating Scientific Python with Intel Optimizations
     It is well known that the performance difference between Python and basic C code can be 200x.
     Did you know that for numerically intensive code there is another 240x or more speedup possible?
     The performance comes from software's ability to take advantage of your CPU's multiple cores,
-    SIMD instructions, and high performance caches.
+    single instruction multiple data (SIMD) instructions, and high performance caches.
     This talk is for Python programmers who want to get the most out of their hardware
     but do not have time or expertise to re-code their applications using techniques such as native 
     extensions or Cython.
@@ -59,17 +59,29 @@ Accelerating Scientific Python with Intel Optimizations
 Introduction
 ------------
 
-Intel released new version of its Distribution.. [TBC]
-We suggest detailed report about optimization work we accomplished for Intel Distribution for Python,
-which might be interesting for developers of SciPy tools.
-It already offered great performance improvements for NumPy*, SciPy*, and Scikit-learn*
-that you can see across a range of Intel processors,
-from Intel |R| Core |TM| CPUs to Intel |R| Xeon |R| and Intel |R| Xeon Phi |TM| processors.
-Here is the list of what we did for update 2:
+Intel released new version of its Distribution [IDP-Release]_. We suggest
+detailed report about optimization work we accomplished for Intel |R|
+Distribution for Python*, which might be interesting for developers of
+SciPy tools. It already offered great performance improvements for
+NumPy*, SciPy*, and Scikit-learn* that you can see across a range of
+Intel processors, from Intel |R| Core |TM| CPUs to Intel |R| Xeon |R|
+and Intel |R| Xeon Phi |TM| processors.
+
 
 Fast Fourier Transforms
 -----------------------
-In addition to initial optimizations of Fast Fourier Transform (FFT) offered in previous releases, Update 2 brings widespread optimizations for NumPy and SciPy FFT. It offers a think layered interface for the Intel |R| Math Kernel Library (Intel |R| MKL) that allows efficient access to native FFT optimizations from a range of NumPy and SciPy functions. The optimizations are provided for real and complex data types in both single and double precision. Update 2 improves performance of both one-dimensional and multi-dimensional transforms, for in-place and out-of-place modes of operation. As a result, performance may improve up to 60x over Update 1 and is now close to performance of native C/Intel MKL.
+
+In addition to initial optimizations of Fast Fourier Transform (FFT)
+offered in previous releases, Update 2 brings widespread optimizations
+for NumPy and SciPy FFT. It offers a think layered interface for the
+Intel |R| Math Kernel Library (Intel |R| MKL) that allows efficient
+access to native FFT optimizations from a range of NumPy and SciPy
+functions. The optimizations are provided for real and complex data
+types in both single and double precision. Update 2 improves
+performance of both one-dimensional and multi-dimensional transforms,
+for in-place and out-of-place modes of operation. As a result,
+performance may improve up to 60x over Update 1 and is now close to
+performance of native C/Intel MKL.
 
 
 .. include:: papers/oleksandr_pavlyk/fft/fft.rst
@@ -82,9 +94,20 @@ Arithmetic and transcendental expressions
 
 Memory management optimizations
 -------------------------------
-Update 2 introduces widespread optimizations in NumPy memory management operations. As a dynamic language, Python manages memory for the user. Memory operations, such as allocation, de-allocation, copy, and move, affect performance of essentially all Python programs.
-Specifically, Update 2 ensures NumPy allocates arrays that are properly aligned in memory on Linux, so that NumPy and SciPy compute functions can benefit from respective aligned versions of SIMD memory access instructions. This is especially relevant for Intel |R| Xeon Phi |TM| processors.
-The most significant improvements in memory optimizations in Update 2 comes from replacing original memory copy and move operations with optimized implementations from Intel MKL. The result: improved performance because these Intel MKL routines are optimized for both a range of Intel CPUs and multiple CPU cores.
+
+Update 2 introduces widespread optimizations in NumPy memory
+management operations. As a dynamic language, Python manages memory
+for the user. Memory operations, such as allocation, de-allocation,
+copy, and move, affect performance of essentially all Python programs.
+Specifically, Update 2 ensures NumPy allocates arrays that are
+properly aligned in memory on Linux, so that NumPy and SciPy compute
+functions can benefit from respective aligned versions of SIMD memory
+access instructions. This is especially relevant for Intel |R| Xeon
+Phi |TM| processors.  The most significant improvements in memory
+optimizations in Update 2 comes from replacing original memory copy
+and move operations with optimized implementations from Intel MKL. The
+result: improved performance because these Intel MKL routines are
+optimized for both a range of Intel CPUs and multiple CPU cores.
 
 Faster Machine Learning with Scikit-learn
 -----------------------------------------
@@ -104,8 +127,14 @@ Auto-parallelization for Numba
 
 Summary
 -------
-The Intel Distribution for Python is powered by Anaconda* and conda build infrastructures that give all Python users the benefit of interoperability within these two environments and access to the optimized packages through a simple conda install command.
-Intel Distribution for Python 2017 Update 2 delivers significant performance optimizations for many core algorithms and Python packages, while maintaining the ease of download and install.
+
+The Intel Distribution for Python is powered by Anaconda* and conda
+build infrastructures that give all Python users the benefit of
+interoperability within these two environments and access to the
+optimized packages through a simple conda install command.
+Intel Distribution for Python 2017 Update 2 delivers significant
+performance optimizations for many core algorithms and Python
+packages, while maintaining the ease of download and install.
 
 
 References
@@ -118,3 +147,5 @@ References
    :ltrim:
 .. |TM| unicode:: 0x2122 .. trade mark sign
    :ltrim:
+
+.. [IDP-Release] `Intel Distribution for Python 2017 Update 3 README <https://software.intel.com/en-us/articles/intel-distribution-for-python-2017-update-3-readme>`_

--- a/papers/oleksandr_pavlyk/parallel/parallel.rst
+++ b/papers/oleksandr_pavlyk/parallel/parallel.rst
@@ -70,7 +70,7 @@ We measure the performance of automatic parallelization over three workloads, co
 
 .. figure:: parallel/parallel_benchmarks.jpg
 
-Auto-parallelization proves to be an effective optimization for these benchmarks, achieving speedups from 5.9x to 11.8x over sequential Numba on 12-core Xeon |R| X5680 @3.33GHz with 64GB RAM. The benchmarks are available as part of Numba's source distribution [numba]_.
+Auto-parallelization proves to be an effective optimization for these benchmarks, achieving speedups from 5.9x to 11.8x over sequential Numba on 12-core Intel |R| Xeon |R| X5680 @3.33GHz with 64GB RAM. The benchmarks are available as part of Numba's source distribution [numba]_.
 
 Our future plan is to support array range selection, enable auto-parallelization of more NumPy functions, as well as adding new features such as iterative stencils. We also plan to implement more optimizations that help make parallel programs run fast, improving both performance and productivity for Python programmers in the scientific domain.
 

--- a/papers/oleksandr_pavlyk/parallel/parallel.rst
+++ b/papers/oleksandr_pavlyk/parallel/parallel.rst
@@ -42,7 +42,9 @@ As an example, a Logistic Regression function is given below:
     @jit(parallel=True)
     def logistic_regression(Y, X, w, iterations):
         for i in range(iterations):
-            w -= np.dot(((1.0 / (1.0 + np.exp(-Y * np.dot(X, w))) - 1.0) * Y), X)
+            w += np.dot(
+                   Y / (1.0 + np.exp(Y * np.dot(X, w))),
+                   X )
         return w
 
 We will not discuss details of the algorithm, but instead focus on how this program behaves with auto-parallelization:

--- a/papers/oleksandr_pavlyk/parallel/parallel.rst
+++ b/papers/oleksandr_pavlyk/parallel/parallel.rst
@@ -70,7 +70,7 @@ We measure the performance of automatic parallelization over three workloads, co
 
 .. figure:: parallel/parallel_benchmarks.jpg
 
-Auto-parallelization proves to be an effective optimization for these benchmarks, achieving speedups from 5.9x to 11.8x over sequential Numba on 12-core Xeon X5680 @3.33GHz with 64GB RAM. The benchmarks are available as part of Numba's source distribution [numba]_. 
+Auto-parallelization proves to be an effective optimization for these benchmarks, achieving speedups from 5.9x to 11.8x over sequential Numba on 12-core Xeon |R| X5680 @3.33GHz with 64GB RAM. The benchmarks are available as part of Numba's source distribution [numba]_.
 
 Our future plan is to support array range selection, enable auto-parallelization of more NumPy functions, as well as adding new features such as iterative stencils. We also plan to implement more optimizations that help make parallel programs run fast, improving both performance and productivity for Python programmers in the scientific domain.
 


### PR DESCRIPTION
Further edits. Fixed width of the jitted code in `parallel.rst`.