### PR TITLE
Editorial changes

### DIFF
--- a/papers/oleksandr_pavlyk/fft/fft.rst
+++ b/papers/oleksandr_pavlyk/fft/fft.rst
@@ -2,8 +2,10 @@
 
 Thanks to Intel |R| MKL's flexibility in its supports for arbitrarily strided input and output arrays [1]_ both one-dimensional and
 multi-dimensional complex Fast Fourier Transforms along distinct axes can be performed directly, without the need to copy the input
-into a contiguous array first. Input strides can be arbitrary, including negative or zero, as long strides remain an 
-integer multiple of array's item size.
+into a contiguous array first (the cost of copying, whose complexity is :math:`\mathcal{O}(n)`, is not negligible compared to the cost 
+of computing the transform, whose complexity is :math:`\mathcal{O}\left(n \log n\right)`, and copying, being memory bound, does not 
+scale well with the number of available cores). Furthermore, input strides can be arbitrary, including negative or zero, as long strides 
+remain an  integer multiple of array's item size, otherwise a copy will be made.
 
 .. raw:: latex
 

--- a/papers/oleksandr_pavlyk/umath/umath.rst
+++ b/papers/oleksandr_pavlyk/umath/umath.rst
@@ -1,7 +1,7 @@
-One of the great benefits found in our Intel |R| Distribution for Python* is the performance boost
+One of the great benefits of the Intel |R| Distribution for Python* is the performance boost
 gained from leveraging SIMD and multithreading in (select) NumPy's UMath arithmetic and
-transcendental operations, on a range of Intel |R| CPUs, from Intel |R| Core |TM| to Intel |R| Xeon
-|TM| & Intel |R| Xeon Phi |TM|. With stock python as our baseline, we demonstrate the scalability of 
+transcendental operations across the range of Intel |R| CPUs, from Intel |R| Core |TM| to Intel |R| Xeon
+|TM| & Intel |R| Xeon Phi |TM|. With stock Python as our baseline, we demonstrate the scalability of 
 Intel |R| Distribution for Python* by using functions that are intensively used in financial math 
 applications and machine learning:
 


### PR DESCRIPTION
1. In fft.rst  added motivation for why it is good to avoid make a copy of the input,
   per Segey's request

2. In umath.rst streamlined the first sentence, removed 'our'

3. In svml.rst adjusted width of the LLVM code section